### PR TITLE
Fixed player being able to place blocks in itself

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -376,11 +376,17 @@ Player.prototype = {
 		if(this.selection.block){
 			block = this.selection.block.getNeighbor(this.selection.normal);
 			if(block && block instanceof blocks.getBlock('air')){
-				var newBlock = block.replace(this.selection.placeBlock);
-				block.chunk.saved = false;
-				//play sound
-				if(newBlock.placeSound.length){
-					createjs.Sound.play(newBlock.placeSound[Math.floor(Math.random() * newBlock.placeSound.length)]);
+				var newBlock = block.replace(this.selection.placeBlock, true);
+				
+				if (collisions.checkCollision(this, newBlock)){
+					newBlock.replace('air');
+				} else {
+					newBlock = block.replace(this.selection.placeBlock, false);
+					block.chunk.saved = false;
+					//play sound
+					if(newBlock.placeSound.length){
+						createjs.Sound.play(newBlock.placeSound[Math.floor(Math.random() * newBlock.placeSound.length)]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I fixed it!
Now it was quite hard to dive in to this code, but I've succeeded.

However, there are the following downsides:
- Block gets placed, then if collides, removed, instead of checking first(But that's impossible since it's air)
- If you plan on "changing" block types, this won't work, since the block is always reverted to air